### PR TITLE
Do some clever Makefile magic to automagically choose the correct pro…

### DIFF
--- a/aws/Makefile
+++ b/aws/Makefile
@@ -1,4 +1,5 @@
-AWS_PROFILE:=dpopes.acct2
+AWS_PROFILE ?= $(shell echo "$$USER.$$(basename $$(dirname $$(pwd)))")
+
 plan: init
 	AWS_PROFILE=${AWS_PROFILE} terraform plan | landscape
 


### PR DESCRIPTION
…file

I'm actually quite pleased with this cleverness! It relies on some naming conventions being followed, but this seems like as good of an approach as any i've seen elsewhere.

I'd ideally not have to provide the environment variable at all. I'm actually not really sure why the provider doesn't automatically use the profile setting. 